### PR TITLE
fix(heartbeat): fail-soft on corrupted vitals in 'Die if it's time' step

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -90,11 +90,31 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ steps.flux-token.outputs.token }}
+          REPO_FULL_NAME: ${{ github.repository }}
         run: |
+          # Fail-soft parse: if vitals.json is corrupted (as happened in
+          # the-dreaming-repo 2026-05-04 → 2026-05-12 with leaked git
+          # conflict markers), crashing here would page Telegram for a
+          # parse error — when the answer to "should we die?" is
+          # unambiguously "no, we can't even tell". Treat a parse failure
+          # as cause_of_death="" (don't delete). Mirrors the pattern from
+          # the-dreaming-repo PR #49.
           if [ -f state/vitals.json ]; then
-            CAUSE=$(python3 -c "import json; v=json.load(open('state/vitals.json')); print(v.get('cause_of_death',''))")
+            CAUSE=$(python3 <<'PY'
+          import json
+          try:
+              with open("state/vitals.json") as f:
+                  print(json.load(f).get("cause_of_death", ""))
+          except Exception as e:
+              # Print to stderr so it appears in the run log, but emit
+              # an empty stdout so CAUSE="" and the silence check fails.
+              import sys
+              print(f"::warning::vitals.json failed to parse ({e}); treating cause_of_death as empty", file=sys.stderr)
+              print("")
+          PY
+          )
             if [ "$CAUSE" = "silence" ]; then
-              echo "Flux has died. Deleting repository."
-              gh repo delete ${{ github.repository }} --yes
+              echo "Umbra has died. Deleting repository."
+              gh repo delete "$REPO_FULL_NAME" --yes
             fi
           fi


### PR DESCRIPTION
## Summary

Port of the-dreaming-repo PR #49 (sibling living-repo). Eliminates a self-wedging gate: when `state/vitals.json` is unparseable, the inline `python3 -c "...json.load..."` crashes the step and would alarm Telegram on a parse error — even though the answer to *"should we die?"* is unambiguously *"no, we can't even tell."*

This was a real incident in the-dreaming-repo (2026-05-04 → 2026-05-12, "conflict-marker deadlock"). Umbra carries the same primitive, vulnerable to the same incident class.

## Change

Replace inline -c with a `<<'PY'` heredoc that wraps `json.load` in try/except:

- **success** → stdout = cause_of_death (existing behavior, untouched)
- **failure** → stderr = `::warning::...` (visible in run log), stdout = `""` → CAUSE="" → silence check fails → no delete

The semantic shift is deliberate: **treat uncertainty as 'alive'**. Killing on a parse error is the wrong direction.

`bash -e` already prevented a spurious `gh repo delete` (parse crash short-circuits before the silence comparison), so worst case was a false alarm — but the alarm itself is real noise.

**Drive-by hygiene:** route `${{ github.repository }}` through a `REPO_FULL_NAME` env var rather than inline template in the `run:` block. Same shape Flux's heartbeat already uses; pre-empts a future zizmor `template-injection` finding.

## Test plan

- [x] YAML re-parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Heredoc indentation produces valid Python after YAML literal-block strip (verified: top-level lines start at column 0; `try:` body indented 4)
- [x] Pattern stress-tested locally against the actual 2026-05-04 corruption shape on the sibling repo before this port

## Sibling context

If you're seeing this PR mention "PR #49" — that's in `nickmeinhold/the-dreaming-repo`, the original incident site. Umbra's twin is structurally simpler (no `--autostash`, so no conflict-marker race surface here), but the unguarded `json.load` is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)